### PR TITLE
Add game percentage fallback for group thirds

### DIFF
--- a/src/components/TennisChampionship.jsx
+++ b/src/components/TennisChampionship.jsx
@@ -472,7 +472,8 @@ const TennisChampionship = () => {
           group: groupName,
           position: 3,
           wins: table[2].wins,
-          setPercentage: table[2].setPercentage
+          setPercentage: table[2].setPercentage,
+          gamePercentage: table[2].gamePercentage
         });
       }
     });
@@ -487,7 +488,10 @@ const TennisChampionship = () => {
     });
     groupThirds.sort((a, b) => {
       if (b.wins !== a.wins) return b.wins - a.wins;
-      return b.setPercentage - a.setPercentage;
+      if (Math.abs(b.setPercentage - a.setPercentage) > 0.1) {
+        return b.setPercentage - a.setPercentage;
+      }
+      return b.gamePercentage - a.gamePercentage;
     });
 
     qualified.push(...groupFirsts);


### PR DESCRIPTION
## Summary
- include `gamePercentage` for third place tracking in `getQualifiedPlayers`
- apply fallback to `gamePercentage` in sorting of third-place players

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862722e76608322aa2c412ec4b503c6