### PR TITLE
Change order so knockout stage appears first

### DIFF
--- a/src/components/TennisChampionship.jsx
+++ b/src/components/TennisChampionship.jsx
@@ -1574,22 +1574,22 @@ groupThirds.sort((a, b) => {
               </p>
             </div>
             
-            <div className="mb-16 md:mb-20">
+            <div className="space-y-12 mb-24 md:mb-32">
+              <h2 className="text-xl md:text-2xl font-light text-gray-800 text-center mb-8 md:mb-10">K.O.-Phase</h2>
+
+              <KOBracket phase="semifinal" title="K.O.-Gruppen" />
+
+              <div className="mt-12">
+                <KOBracket phase="final" title="Finale" />
+              </div>
+            </div>
+
+            <div className="pt-12 md:pt-16 border-t-2 border-gray-200">
               <h2 className="text-xl md:text-2xl font-light text-gray-800 mb-8 md:mb-10 text-center">Gruppenphase</h2>
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-10 md:gap-12 lg:gap-16">
                 {Object.entries(GROUPS).map(([groupName, players]) => (
                   <GroupCard key={groupName} groupName={groupName} players={players} />
                 ))}
-              </div>
-            </div>
-
-            <div className="space-y-12 pt-8 md:pt-12 border-t-2 border-gray-200">
-              <h2 className="text-xl md:text-2xl font-light text-gray-800 text-center">K.O.-Phase</h2>
-              
-              <KOBracket phase="semifinal" title="K.O.-Gruppen" />
-              
-              <div className="mt-12">
-                <KOBracket phase="final" title="Finale" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show knockout bracket above group tables in the overview
- increase spacing between KO bracket and group tables for clarity

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629c1d72a48322b9a80d49d234962f