### PR TITLE
Add knockout intro heading

### DIFF
--- a/src/components/KOBracket.jsx
+++ b/src/components/KOBracket.jsx
@@ -23,7 +23,7 @@ const KOBracket = ({ phase, title, koGroups, qualifiedPlayers, matches }) => {
 
     return (
       <div className="space-y-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-12">
           <KOGroupCard groupName="A" players={koGroups.A} matches={matches} />
           <KOGroupCard groupName="B" players={koGroups.B} matches={matches} />
         </div>

--- a/src/components/TennisChampionship.jsx
+++ b/src/components/TennisChampionship.jsx
@@ -993,9 +993,15 @@ const TennisChampionship = () => {
                 </div>
               </div>
               <p className="mt-6 text-lg text-gray-600 max-w-2xl mx-auto leading-relaxed px-4">
-                Willkommen zur diesjährigen Vereinsmeisterschaft! 12 Spieler treten in 3 Gruppen gegeneinander an. 
+                Willkommen zur diesjährigen Vereinsmeisterschaft! 12 Spieler treten in 3 Gruppen gegeneinander an.
                 Die Endrunde spielen 8 Spieler. Jeweils die 2 Besten aus den 3 Gruppen plus die 2 besten 3ten aus allen Gruppen.
                 Gespielt wird im Best-of-3-Format mit Match-Tiebreak bei 1:1 Sätzen.
+              </p>
+              <h2 className="mt-10 text-2xl md:text-3xl font-light text-gray-800">
+                💥 Game. Set. Knockout!
+              </h2>
+              <p className="mt-4 text-gray-600">
+                Die Gruppenphase ist Geschichte – jetzt beginnt der wahre Wettkampf!
               </p>
             </div>
             


### PR DESCRIPTION
## Summary
- introduce new heading and text on overview page
- widen the gap between KO group cards for better spacing

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863874ab7d48322b6818685e7389cc3