### PR TITLE
Rename KO Phase to Endrunde

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Eine moderne Web-Anwendung zur Verwaltung der Tennis-Vereinsmeisterschaft des TV
 
 - **Gruppenphase**: 3 Gruppen mit je 4 Spielern
 - **Automatische Tabellen**: Punkte, Siege, Niederlagen, Sätze
-- **K.O.-Phase**: 8 qualifizierte Spieler (3 Gruppensieger + 3 Gruppenzweite + 2 beste Gruppendritten)
+- **Endrunde**: 8 qualifizierte Spieler (3 Gruppensieger + 3 Gruppenzweite + 2 beste Gruppendritten)
 - **Tennis-Score-Validierung**: Korrekte Überprüfung aller Tennis-Ergebnisse
 - **Admin-Modus**: Erweiterte Verwaltungsfunktionen
 - **Responsive Design**: Funktioniert auf allen Geräten
@@ -61,7 +61,7 @@ Die Anwendung ist dann unter `http://localhost:3000` verfügbar.
 - **Admin-PIN**: `9999` - Erweiterte Verwaltung
 
 ### Navigation
-- **Überblick**: Gesamtansicht aller Gruppen und K.O.-Phase
+- **Überblick**: Gesamtansicht aller Gruppen und Endrunde
 - **Gruppen**: Detaillierte Gruppentabellen
 - **Endrunde**: Qualifikation und Endrunden-Matches
 - **Finale**: Finale der besten 2 Spieler

--- a/src/components/KOBracket.jsx
+++ b/src/components/KOBracket.jsx
@@ -52,7 +52,7 @@ const KOBracket = ({ phase, title, koGroups, qualifiedPlayers, matches }) => {
           </h3>
           <div className="text-center py-12 text-gray-500">
             <Trophy className="mx-auto mb-4 opacity-30" size={48} />
-            <p>K.O.-Gruppen noch nicht abgeschlossen</p>
+            <p>End-Gruppen noch nicht abgeschlossen</p>
           </div>
         </div>
       );
@@ -65,13 +65,13 @@ const KOBracket = ({ phase, title, koGroups, qualifiedPlayers, matches }) => {
           {title}
         </h3>
         <div className="text-center py-6">
-          <p className="text-gray-600 mb-4">Die Top 2 aus jeder K.O.-Gruppe spielen im Finale</p>
+          <p className="text-gray-600 mb-4">Die Top 2 aus jeder End-Gruppe spielen im Finale</p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {finalists.slice(0, 4).map((player, index) => (
               <div key={index} className="bg-gradient-to-r from-yellow-50 to-yellow-100 border border-yellow-300 rounded-lg p-4">
                 <div className="font-semibold text-gray-800">{player.name}</div>
                 <div className="text-sm text-gray-600">
-                  K.O. Gruppe {index < 2 ? 'A' : 'B'} - Platz {(index % 2) + 1}
+                  End-Gruppe {index < 2 ? 'A' : 'B'} - Platz {(index % 2) + 1}
                 </div>
               </div>
             ))}

--- a/src/components/KOGroupCard.jsx
+++ b/src/components/KOGroupCard.jsx
@@ -21,7 +21,7 @@ const KOGroupCard = ({ groupName, players, matches }) => {
       <h3 className="text-lg md:text-xl font-semibold text-gray-800 mb-4 flex items-center justify-between">
         <div className="flex items-center">
           <Trophy className="mr-2 text-blue-500" size={20} />
-          K.O. Gruppe {groupName}
+          End-Gruppe {groupName}
         </div>
         <span className="text-sm text-gray-500">
           {playedMatches}/{totalMatches} Matches

--- a/src/components/TennisChampionship.jsx
+++ b/src/components/TennisChampionship.jsx
@@ -527,8 +527,8 @@ const TennisChampionship = () => {
       setMatches(currentMatches => [...currentMatches, savedMatch]);
       setNextMatchId(nextMatchId + 1);
       
-      const phaseText = match.phase === 'group' ? `Gruppe ${match.group}` : 
-                       match.phase === 'semifinal' ? `K.O. Gruppe ${match.koGroup}` : 'Finale';
+      const phaseText = match.phase === 'group' ? `Gruppe ${match.group}` :
+                       match.phase === 'semifinal' ? `End-Gruppe ${match.koGroup}` : 'Finale';
       
       const statusText = connectionStatus === 'connected' ? 
         '✅ In Airtable gespeichert!' : 
@@ -880,7 +880,7 @@ const TennisChampionship = () => {
 
     const getPhaseTitle = (match) => {
       if (match.phase === 'group') return `Gruppe ${match.group}`;
-      if (match.phase === 'semifinal') return `K.O. Gruppe ${match.koGroup}`;
+      if (match.phase === 'semifinal') return `End-Gruppe ${match.koGroup}`;
       if (match.phase === 'final') return 'Finale';
       return 'Unbekannt';
     };
@@ -1011,11 +1011,11 @@ const TennisChampionship = () => {
 
             <div className="space-y-12 mb-16 md:mb-20">
 
-              <h2 className="text-xl md:text-2xl font-light text-gray-800 text-center mb-8 md:mb-10">K.O.-Phase</h2>
+              <h2 className="text-xl md:text-2xl font-light text-gray-800 text-center mb-8 md:mb-10">Endrunde</h2>
 
               <KOBracket
                 phase="semifinal"
-                title="K.O.-Gruppen"
+                title="End-Gruppen"
                 koGroups={getKOGroups}
                 qualifiedPlayers={getQualifiedPlayers}
                 matches={matches}
@@ -1294,7 +1294,7 @@ const TennisChampionship = () => {
                           <tr>
                             <td className="py-2 text-red-700">Endrunde</td>
                             <td className="py-2 text-red-700">1. - 31. Juli 2025</td>
-                            <td className="py-2 text-red-700">Alle K.O.-Spiele</td>
+                            <td className="py-2 text-red-700">Alle Endrunden-Spiele</td>
                           </tr>
                         </tbody>
                       </table>
@@ -1531,14 +1531,14 @@ const TennisChampionship = () => {
                         >
                           <option value="group">Gruppenphase</option>
                           {getQualifiedPlayers.length >= 8 && (
-                            <option value="semifinal">K.O.-Gruppen</option>
+                            <option value="semifinal">Endrunde</option>
                           )}
                         </select>
                       </div>
                       
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
-                          {newMatch.phase === 'group' ? 'Gruppe' : 'K.O. Gruppe'}
+                          {newMatch.phase === 'group' ? 'Gruppe' : 'End-Gruppe'}
                         </label>
                         <select
                           value={newMatch.phase === 'group' ? newMatch.group : newMatch.koGroup}
@@ -1559,8 +1559,8 @@ const TennisChampionship = () => {
                             </>
                           ) : (
                             <>
-                              <option value="A">K.O. Gruppe A</option>
-                              <option value="B">K.O. Gruppe B</option>
+                              <option value="A">End-Gruppe A</option>
+                              <option value="B">End-Gruppe B</option>
                             </>
                           )}
                         </select>


### PR DESCRIPTION
## Summary
- rename 'K.O.-Phase' references to 'Endrunde'
- rename texts for K.O. groups to 'End-Gruppe'

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686391585d188322936021389add2347