### PR TITLE
Fix match counts for duplicates

### DIFF
--- a/src/components/KOGroupCard.jsx
+++ b/src/components/KOGroupCard.jsx
@@ -9,12 +9,17 @@ const KOGroupCard = ({ groupName, players, matches }) => {
   );
 
   const totalMatches = generatePairings(players.map((p) => p.name)).length;
-  const playedMatches = matches.filter(
-    (m) =>
-      m.phase === 'semifinal' &&
-      m.koGroup === groupName &&
-      m.status === 'completed'
-  ).length;
+  const playedMatches = useMemo(() => {
+    const keys = matches
+      .filter(
+        (m) =>
+          m.phase === 'semifinal' &&
+          m.koGroup === groupName &&
+          m.status === 'completed'
+      )
+      .map((m) => [m.player1, m.player2].sort().join('-'));
+    return new Set(keys).size;
+  }, [groupName, matches]);
 
   return (
     <div className="bg-white rounded-2xl shadow-xl border-2 border-gray-100 p-4 md:p-6 hover:shadow-2xl hover:border-blue-200 transition-all duration-300">

--- a/src/components/TennisChampionship.jsx
+++ b/src/components/TennisChampionship.jsx
@@ -753,7 +753,12 @@ const TennisChampionship = () => {
   const GroupCard = ({ groupName, players }) => {
     const tableData = useMemo(() => calculateGroupTable(groupName), [groupName, calculateGroupTable]);
     const totalMatches = generatePairings(players).length;
-    const playedMatches = matches.filter(m => m.group === groupName && m.status === 'completed').length;
+    const playedMatches = useMemo(() => {
+      const keys = matches
+        .filter(m => m.group === groupName && m.status === 'completed')
+        .map(m => [m.player1, m.player2].sort().join('-'));
+      return new Set(keys).size;
+    }, [groupName, matches]);
     
     return (
       <div className="bg-white rounded-2xl shadow-xl border-2 border-gray-100 p-4 md:p-6 hover:shadow-2xl hover:border-blue-200 transition-all duration-300">


### PR DESCRIPTION
## Summary
- handle duplicate matches when counting played matches in KOGroupCard
- deduplicate played matches in TennisChampionship GroupCard

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2d94dec88322ad8315b3afc81ae3